### PR TITLE
"Fixed" the crashing when port is in use

### DIFF
--- a/Server/Network.cpp
+++ b/Server/Network.cpp
@@ -32,10 +32,8 @@ namespace Network
 		
 		if (pRakServer->Startup(szHostAddress, usPort, iConnections) != RakNet::StartupResult::RAKNET_STARTED)
 		{
-			if (MessageBoxA(NULL, "Couldn't start", "SA-MP+ - Error", MB_OK | MB_ICONERROR))
-				exit(EXIT_FAILURE);
-				//Not really sure if there's anything to clean up at this stage.
-			//abort();
+			Utility::Printf("Couldn't start SA-MP+ plugin");
+			exit(EXIT_FAILURE);
 		}
 
 		bInitialized = true;


### PR DESCRIPTION
Instead of crashing when the port is in use, I show a message box saying that SA-MP+ couldn't start.
Not really a big change and nothing too fancy, but hey, it's something :+1: 
